### PR TITLE
Add a standardised contact section to the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
 # brainglobe-stitch
+
+
+## Seeking help or contributing
+We are always happy to help users of our tools, and welcome any contributions. If you would like to get in contact with us for any reason, please see the [contact page of our website](https://brainglobe.info/contact.html).


### PR DESCRIPTION
This is copied from the new section on every other readme. The idea is that we just need to keep the one page on the website up to date. 