### PR TITLE
Schedule weekly tests

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -6,6 +6,9 @@ on:
       - '*'
     tags:
       - '*'
+  schedule:
+  # Runs at 6:10am UTC on Monday
+    - cron: '10 6 * * 1'
   pull_request:
 
 jobs:


### PR DESCRIPTION
Schedule tests to run weekly to make sure there are no installation issues, and to keep the cache fresh.