### PR TITLE
Add on-failure workflow to test and deploy

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -75,7 +75,7 @@ jobs:
             footer: "Linked Repo <${{github.server_url}}/${{github.repository}}|${{github.repository}}> | <${{github.server_url}}/${{github.repository}}/actions/runs/${{github.event.workflow_run.id}}|View Failure>"
 #            notify_when: "failure"
           env:
-            SLACK_WEBHOOK_URL: ${{ secrets.SLACK_NOTIFYBOT_WEBHOOK_URL }}
+            SLACK_WEBHOOK_URL: ${{ secrets.SLACK_NOTIFYBOT_WEBHOOOK_URL }}
 
   build_sdist_wheels:
     name: Build source distribution

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -60,6 +60,23 @@ jobs:
           python-version: ${{ matrix.python-version }}
           secret-codecov-token: ${{ secrets.CODECOV_TOKEN }}
 
+  on-failure:
+    name: Notify slack on scheduled failure
+    needs: [test]
+#    if: github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    steps:
+        - uses: ravsamhq/notify-slack-action@v2
+          if: always()
+          with:
+            status: ${{ github.event.workflow_run.conclusion }}
+            notification_title: " ${{github.event.workflow_run.name}} - ${{github.event.workflow_run.conclusion}} on ${{github.event.workflow_run.head_branch}} - <${{github.server_url}}/${{github.repository}}/actions/runs/${{github.event.workflow_run.id}}|View Failure>"
+            message_format: ":fire: *${{github.event.workflow_run.name}}* ${{github.event.workflow_run.conclusion}} in <${{github.server_url}}/${{github.repository}}/${{github.event.workflow_run.head_branch}}|${{github.repository}}>"
+            footer: "Linked Repo <${{github.server_url}}/${{github.repository}}|${{github.repository}}> | <${{github.server_url}}/${{github.repository}}/actions/runs/${{github.event.workflow_run.id}}|View Failure>"
+#            notify_when: "failure"
+          env:
+            SLACK_WEBHOOK_URL: ${{ secrets.SLACK_NOTIFYBOT_WEBHOOK_URL }}
+
   build_sdist_wheels:
     name: Build source distribution
     needs: [test]

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -64,18 +64,13 @@ jobs:
     name: Notify slack on scheduled failure
     needs: [test]
 #    if: github.event_name == 'schedule'
-    runs-on: ubuntu-latest
     steps:
-        - uses: ravsamhq/notify-slack-action@v2
-          if: always()
-          with:
-            status: ${{ github.event.workflow_run.conclusion }}
-            notification_title: " ${{github.event.workflow_run.name}} - ${{github.event.workflow_run.conclusion}} on ${{github.event.workflow_run.head_branch}} - <${{github.server_url}}/${{github.repository}}/actions/runs/${{github.event.workflow_run.id}}|View Failure>"
-            message_format: ":fire: *${{github.event.workflow_run.name}}* ${{github.event.workflow_run.conclusion}} in <${{github.server_url}}/${{github.repository}}/${{github.event.workflow_run.head_branch}}|${{github.repository}}>"
-            footer: "Linked Repo <${{github.server_url}}/${{github.repository}}|${{github.repository}}> | <${{github.server_url}}/${{github.repository}}/actions/runs/${{github.event.workflow_run.id}}|View Failure>"
-#            notify_when: "failure"
-          env:
-            SLACK_WEBHOOK_URL: ${{ secrets.SLACK_NOTIFYBOT_WEBHOOOK_URL }}
+      - uses: ravsamhq/notify-slack-action@v2
+        if: always()
+        with:
+          status: ${{ job.status }} # required
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_NOTIFYBOT_WEBHOOK_URL }} # required
 
   build_sdist_wheels:
     name: Build source distribution

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -62,6 +62,7 @@ jobs:
 
   on-failure:
     name: Notify slack on scheduled failure
+    runs-on: ubuntu-latest
     needs: [test]
 #    if: github.event_name == 'schedule'
     steps:

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -64,13 +64,12 @@ jobs:
     name: Notify slack on scheduled failure
     runs-on: ubuntu-latest
     needs: [test]
-#    if: github.event_name == 'schedule'
     steps:
       - uses: ravsamhq/notify-slack-action@v2
-        if: ${{ github.event_name != 'schedule' }}
+        if: ${{ github.event_name == 'schedule' }}
         with:
           status: ${{ job.status }} # required
-          notify_when: 'success,failure,cancelled'
+          notify_when: 'failure'
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_NOTIFYBOT_WEBHOOK_URL }} # required
 

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -8,7 +8,7 @@ on:
       - '*'
   schedule:
   # Runs at 6:10am UTC on Monday
-    - cron: '10 6 * * 1'
+    - cron: '0/10 * * * *'
   pull_request:
 
 jobs:
@@ -67,9 +67,10 @@ jobs:
 #    if: github.event_name == 'schedule'
     steps:
       - uses: ravsamhq/notify-slack-action@v2
-        if: always()
+        if: ${{ github.event_name == 'schedule' }}
         with:
           status: ${{ job.status }} # required
+          notify_when: 'success,failure,cancelled'
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_NOTIFYBOT_WEBHOOK_URL }} # required
 

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -67,7 +67,7 @@ jobs:
 #    if: github.event_name == 'schedule'
     steps:
       - uses: ravsamhq/notify-slack-action@v2
-        if: ${{ github.event_name == 'schedule' }}
+        if: ${{ github.event_name != 'schedule' }}
         with:
           status: ${{ job.status }} # required
           notify_when: 'success,failure,cancelled'

--- a/tests/test_unit/test_tile.py
+++ b/tests/test_unit/test_tile.py
@@ -27,3 +27,7 @@ def test_tile_init():
     assert tile.channel_name == ""
     assert tile.illumination_id == illumination_id
     assert tile.angle == angle
+
+
+def test_always_fail():
+    assert False


### PR DESCRIPTION
This adds an extra job that runs only if the workflow was triggered via schedule. This job should send a slack notification if the scheduled tests fail.

To test this, I've temporarily made the cron job run every 10 mins, and added a test that always fails.

This needs to be merged to main to test. After testing I'll make a new PR reverting the cron job schedule and removing the failing test.

If this works, we need to put the webhook URL as an organization secret and I'll update the `test_and_deploy.yml` for all BrainGlobe repos.