### PR TITLE
Extract and replace data in overlapping regions between tiles

### DIFF
--- a/brainglobe_stitch/stitching_widget.py
+++ b/brainglobe_stitch/stitching_widget.py
@@ -439,7 +439,7 @@ class StitchingWidget(QWidget):
         Check if the selected ImageJ path is valid. If valid, enable the
         stitch button. Otherwise, show a warning.
         """
-        if self.imagej_path and self.imagej_path.is_file():
+        if self.imagej_path and self.imagej_path.exists():
             self.stitch_button.setEnabled(True)
         else:
             error_message = (

--- a/brainglobe_stitch/tile.py
+++ b/brainglobe_stitch/tile.py
@@ -97,9 +97,14 @@ class Overlap:
         tile_j: Tile
             The second tile.
         """
+        # Store the starting coordinates for the overlap in the fused image
         self.coordinates: npt.NDArray = overlap_coordinates
+        # Store the size of overlap for each level of the resolution pyramid
         self.size: List[npt.NDArray] = [overlap_size]
         self.tiles: Tuple[Tile, Tile] = (tile_i, tile_j)
+        # Store the starting coordinates for the overlap for each level of the
+        # resolution pyramid. The tuple contains the starting coordinates for
+        # the overlap in each tile.
         self.local_coordinates: List[Tuple[npt.NDArray, npt.NDArray]] = [
             (
                 np.zeros(self.coordinates.shape),
@@ -116,26 +121,33 @@ class Overlap:
         tile_shape = self.tiles[0].data_pyramid[0].shape
         resolution_pyramid = self.tiles[0].resolution_pyramid
 
-        for i in range(self.coordinates.shape[0]):
-            if self.tiles[0].position[i] < self.tiles[1].position[i]:
-                self.local_coordinates[0][0][i] = (
-                    tile_shape[i] - self.size[0][i]
+        for dim_index in range(self.coordinates.shape[0]):
+            if (
+                self.tiles[0].position[dim_index]
+                < self.tiles[1].position[dim_index]
+            ):
+                self.local_coordinates[0][0][dim_index] = (
+                    tile_shape[dim_index] - self.size[0][dim_index]
                 )
-                self.local_coordinates[0][1][i] = 0
+                self.local_coordinates[0][1][dim_index] = 0
             else:
-                self.local_coordinates[0][0][i] = 0
-                self.local_coordinates[0][1][i] = (
-                    tile_shape[i] - self.size[0][i]
+                self.local_coordinates[0][0][dim_index] = 0
+                self.local_coordinates[0][1][dim_index] = (
+                    tile_shape[dim_index] - self.size[0][dim_index]
                 )
 
-        for j in range(1, len(resolution_pyramid)):
+        for resolution_level in range(1, len(resolution_pyramid)):
             self.local_coordinates.append(
                 (
-                    self.local_coordinates[0][0] // resolution_pyramid[j],
-                    self.local_coordinates[0][1] // resolution_pyramid[j],
+                    self.local_coordinates[0][0]
+                    // resolution_pyramid[resolution_level],
+                    self.local_coordinates[0][1]
+                    // resolution_pyramid[resolution_level],
                 )
             )
-            self.size.append(self.size[0] // resolution_pyramid[j])
+            self.size.append(
+                self.size[0] // resolution_pyramid[resolution_level]
+            )
 
     def extract_tile_overlaps(
         self, resolution_level: int

--- a/brainglobe_stitch/tile.py
+++ b/brainglobe_stitch/tile.py
@@ -1,4 +1,4 @@
-from typing import Dict, List
+from typing import Dict, List, Tuple
 
 import dask.array as da
 import numpy as np
@@ -55,3 +55,148 @@ class Tile:
         self.tile_id: int = int(attributes["tile"])
         self.illumination_id: int = int(attributes["illumination"])
         self.angle: float = float(attributes["angle"])
+
+
+class Overlap:
+    """
+    Overlap class to store information about the overlap between two tiles.
+
+    Attributes
+    ----------
+    coordinates : npt.NDArray
+        The coordinates for the start of the overlap in the fused image.
+    size : List[npt.NDArray]
+        The size of the overlap in the fused image for each resolution pyramid.
+    tiles : Tuple[Tile, Tile]
+        The overlapping tiles.
+    local_coordinates : List[Tuple[npt.NDArray, npt.NDArray]]
+        A list of tuples representing the starting coordinates for the overlap
+        in each tile's data pyramid for each resolution pyramid level.
+        The tuple contains the starting coordinates for the overlap in each
+        tile.
+    """
+
+    def __init__(
+        self,
+        overlap_coordinates: npt.NDArray,
+        overlap_size: npt.NDArray,
+        tile_i: Tile,
+        tile_j: Tile,
+    ):
+        """
+        Initialize the overlap.
+
+        Parameters
+        ----------
+        overlap_coordinates: npt.NDArray
+            The starting coordinates for the overlap in the fused image.
+        overlap_size: npt.NDArray
+            The size of the overlap in the fused image [z,y,x].
+        tile_i: Tile
+            The first tile.
+        tile_j: Tile
+            The second tile.
+        """
+        self.coordinates: npt.NDArray = overlap_coordinates
+        self.size: List[npt.NDArray] = [overlap_size]
+        self.tiles: Tuple[Tile, Tile] = (tile_i, tile_j)
+        self.local_coordinates: List[Tuple[npt.NDArray, npt.NDArray]] = [
+            (
+                np.zeros(self.coordinates.shape),
+                np.zeros(self.coordinates.shape),
+            ),
+        ]
+        self.get_local_overlap_coordinates()
+
+    def get_local_overlap_coordinates(self) -> None:
+        """
+        Calculate the starting coordinates for the overlap in
+        each tile's data pyramid.
+        """
+        tile_shape = self.tiles[0].data_pyramid[0].shape
+        resolution_pyramid = self.tiles[0].resolution_pyramid
+
+        for i in range(self.coordinates.shape[0]):
+            if self.tiles[0].position[i] < self.tiles[1].position[i]:
+                self.local_coordinates[0][0][i] = (
+                    tile_shape[i] - self.size[0][i]
+                )
+                self.local_coordinates[0][1][i] = 0
+            else:
+                self.local_coordinates[0][0][i] = 0
+                self.local_coordinates[0][1][i] = (
+                    tile_shape[i] - self.size[0][i]
+                )
+
+        for j in range(1, len(resolution_pyramid)):
+            self.local_coordinates.append(
+                (
+                    self.local_coordinates[0][0] // resolution_pyramid[j],
+                    self.local_coordinates[0][1] // resolution_pyramid[j],
+                )
+            )
+            self.size.append(self.size[0] // resolution_pyramid[j])
+
+    def extract_tile_overlaps(
+        self, resolution_level: int
+    ) -> Tuple[da.Array, da.Array]:
+        """
+        Extract the overlap data from both tiles at a given resolution level.
+
+        Parameters
+        ----------
+        resolution_level: int
+            The resolution level to extract the overlap data from.
+
+        Returns
+        -------
+        Tuple[da.Array, da.Array]
+            The overlapping data for both tiles.
+        """
+        scaled_coordinates = self.local_coordinates[resolution_level]
+        scaled_size = self.size[resolution_level]
+
+        i_overlap = self.tiles[0].data_pyramid[resolution_level][
+            scaled_coordinates[0][0] : scaled_coordinates[0][0]
+            + scaled_size[0],
+            scaled_coordinates[0][1] : scaled_coordinates[0][1]
+            + scaled_size[1],
+            scaled_coordinates[0][2] : scaled_coordinates[0][2]
+            + scaled_size[2],
+        ]
+
+        j_overlap = self.tiles[1].data_pyramid[resolution_level][
+            scaled_coordinates[1][0] : scaled_coordinates[1][0]
+            + scaled_size[0],
+            scaled_coordinates[1][1] : scaled_coordinates[1][1]
+            + scaled_size[1],
+            scaled_coordinates[1][2] : scaled_coordinates[1][2]
+            + scaled_size[2],
+        ]
+
+        return i_overlap, j_overlap
+
+    def replace_overlap_data(self, resolution_level: int, new_data: da.Array):
+        """
+        Replace the overlapping data for both tiles at a given resolution
+        level.
+
+        Parameters
+        ----------
+        resolution_level: int
+            The resolution level to replace the overlapping data at.
+        new_data:
+            The new data to replace the overlapping data with.
+        """
+        scaled_coordinates = self.local_coordinates[resolution_level]
+        scaled_size = self.size[resolution_level]
+
+        for idx, tile in enumerate(self.tiles):
+            tile.data_pyramid[resolution_level][
+                scaled_coordinates[idx][0] : scaled_coordinates[idx][0]
+                + scaled_size[0],
+                scaled_coordinates[idx][1] : scaled_coordinates[idx][1]
+                + scaled_size[1],
+                scaled_coordinates[idx][2] : scaled_coordinates[idx][2]
+                + scaled_size[2],
+            ] = new_data

--- a/tests/test_unit/test_tile.py
+++ b/tests/test_unit/test_tile.py
@@ -182,16 +182,15 @@ def test_extract_tile_overlaps(generate_overlap):
         ).all()
 
 
-def test_replace_overlap_data(generate_overlap):
+@pytest.mark.parametrize("res_level", [0, 1, 2])
+def test_replace_overlap_data(generate_overlap, res_level):
     """
     Test that the overlap data is replaced with zeros at the base
     resolution level.
     """
     overlap = generate_overlap
-
-    new_data = da.zeros(overlap.size[0], dtype=np.int16)
-    overlap.replace_overlap_data(0, new_data)
-    res_level = 0
+    new_data = da.zeros(overlap.size[res_level], dtype=np.int16)
+    overlap.replace_overlap_data(res_level, new_data)
 
     # Check that the overlap data has been replaced with zeros
     for i in range(len(overlap.tiles)):


### PR DESCRIPTION
Before submitting a pull request (PR), please read the [contributing guide](https://github.com/brainglobe/.github/blob/main/CONTRIBUTING.md).

Please fill out as much of this template as you can, but if you have any problems or questions, just leave a comment and we will help out :)

## Description

**What is this PR**

- [ ] Bug fix
- [x] Addition of a new feature
- [ ] Other

**Why is this PR needed?**
In order to correct for brightness differences, and interpolate over the stitches in the final fused images it's important to keep track of which tiles overlap and the coordinates of the overlap in both `local` (relative to the tile itself) and `global` (relative to the final fused image) coordinates.   

**What does this PR do?**
* **`brainglobe_stitch/tile.py`**: Introduced the `Overlap` class to store and manage information about the overlap between two tiles, including methods to calculate local overlap coordinates and extract/replace overlap data.

* **`brainglobe_stitch/image_mosaic.py`**: Updated the `ImageMosaic` class to include an `overlaps` attribute and methods to calculate overlaps between tiles. This involved modifying the constructor, `load_mesospim_directory`, and `stitch` methods, and adding the `calculate_overlaps` method.

* **`tests/test_unit/test_tile.py`**: Added new tests for the `Overlap` class, including tests for initialization, local coordinate calculation, overlap data extraction, and data replacement. These tests ensure that the overlap functionality works correctly.

## How has this PR been tested?
Tests added to cover the new functionality.

NOTE:
To test the functionality locally you must install Fiji and also add BigStitcher to the update sites. This can be done using the GUI [see here](https://imagej.net/plugins/bigstitcher/#download) or via the command line after installing Fiji.

./ImageJ-linux64 --update add-update-sites "BigStitcherUpdate" "https://sites.imagej.net/BigStitcher/"
./ImageJ-linux64 --update update

Replace ImageJ-linux64 with the path to the local ImageJ executable.

Three different datasets are available for testing:

- Tiny (~28 MB): this is mostly used for automated testing and doesn't work for visual inspection. It can be downloaded [here](https://gin.g-node.org/IgorTatarnikov/brainglobe-stitch-test/raw/master/brainglobe-stitch/brainglobe-stitch-test-data.zip).
- Small (~1.8 GB): this dataset is more useful for visual inspection. It can be downloaded [here](https://gin.g-node.org/IgorTatarnikov/brainglobe-stitch-test/raw/master/brainglobe-stitch/big_test_data.zip).
- A full size dataset is available (~130 GB): this dataset works best for testing overall performance, especially when reading or writing data. It's available by request.

## Is this a breaking change?
No

## Does this PR require an update to the documentation?
Yes, will come in subsequent PR.

## Checklist:

- [x] The code has been tested locally
- [x] Tests have been added to cover all new functionality (unit & integration)
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)

