### PR TITLE
Import Qt elements from qt-niu

### DIFF
--- a/brainglobe_stitch/stitching_widget.py
+++ b/brainglobe_stitch/stitching_widget.py
@@ -8,11 +8,11 @@ import h5py
 import napari
 import numpy as np
 import numpy.typing as npt
-from brainglobe_utils.qtpy.dialog import display_info, display_warning
 from brainglobe_utils.qtpy.logo import header_widget
 from napari import Viewer
 from napari.qt.threading import create_worker
 from napari.utils.notifications import show_info, show_warning
+from qt_niu.dialog import display_info, display_warning
 from qtpy.QtWidgets import (
     QComboBox,
     QFileDialog,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,8 @@ dependencies = [
     "zarr",
     "numpy",
     "qtpy",
-    "tifffile"
+    "tifffile",
+    "qt-niu"
 ]
 
 [project.urls]


### PR DESCRIPTION
Re-useable Qt elements have been moved from brainglobe-utils to [qt-niu](https://github.com/neuroinformatics-unit/qt-niu). This PR changes the imports accordingly.