### PR TITLE
Use napari thread_worker for stitching and pyramid tasks with Activity Dock progress

### DIFF
--- a/brainglobe_stitch/stitching_widget.py
+++ b/brainglobe_stitch/stitching_widget.py
@@ -91,6 +91,7 @@ def stitching_worker(image_mosaic, imagej_path, resolution_level, channel):
     )
     return True
 
+
 @thread_worker(
     progress={"total": 0, "desc": "Fusing tiles"},
 )
@@ -108,6 +109,7 @@ def fuse_worker(
         interpolate=interpolate,
     )
     return True
+
 
 class StitchingWidget(QWidget):
     """
@@ -337,7 +339,7 @@ class StitchingWidget(QWidget):
 
         self.layout().addWidget(self.progress_bar)
         self.progress_bar.setVisible(False)
-    
+
     def _activate_activity_dock(self):
         self._viewer.window._status_bar._toggle_activity_dock(True)
 

--- a/brainglobe_stitch/stitching_widget.py
+++ b/brainglobe_stitch/stitching_widget.py
@@ -89,6 +89,24 @@ def stitching_worker(image_mosaic, imagej_path, resolution_level, channel):
     )
     return True
 
+@thread_worker(
+    progress={"total": 0, "desc": "Fusing tiles"},
+)
+def fuse_worker(
+    image_mosaic,
+    output_path,
+    normalise_intensity,
+    percentile,
+    interpolate,
+):
+    image_mosaic.fuse(
+        output_path,
+        normalise_intensity=normalise_intensity,
+        normalise_intensity_percentile=percentile,
+        interpolate=interpolate,
+    )
+    return True
+
 class StitchingWidget(QWidget):
     """
     napari widget for stitching large tiled 3d images.
@@ -317,7 +335,12 @@ class StitchingWidget(QWidget):
 
         self.layout().addWidget(self.progress_bar)
         self.progress_bar.setVisible(False)
+    
+    def _activate_activity_dock(self):
         self._viewer.window._status_bar._toggle_activity_dock(True)
+
+    def _deactivate_activity_dock(self):
+        self._viewer.window._status_bar._toggle_activity_dock(False)
 
     def _on_open_file_dialog_clicked(self) -> None:
         """
@@ -353,6 +376,8 @@ class StitchingWidget(QWidget):
         self.progress_bar.setRange(0, 100)
 
         worker = create_pyramid_worker(self.h5_path)
+        self._activate_activity_dock()
+
         worker.yielded.connect(self.progress_bar.setValue)
         worker.finished.connect(self._create_pyramid_finished)
         worker.start()
@@ -366,6 +391,7 @@ class StitchingWidget(QWidget):
         self.create_pyramid_button.setEnabled(False)
         self.progress_bar.reset()
         self.progress_bar.setVisible(False)
+        self._deactivate_activity_dock()
 
     def _on_add_tiles_button_clicked(self) -> None:
         """
@@ -482,6 +508,7 @@ class StitchingWidget(QWidget):
         self.adjust_intensity_button.setEnabled(False)
         self.liner_interpolation_button.setEnabled(False)
         self.reset_preview_button.setEnabled(False)
+        self._activate_activity_dock()
         worker.finished.connect(self._on_stitch_finished)
         worker.start()
 
@@ -498,6 +525,7 @@ class StitchingWidget(QWidget):
         self.adjust_intensity_button.setEnabled(True)
         self.liner_interpolation_button.setEnabled(True)
         self.reset_preview_button.setEnabled(True)
+        self._deactivate_activity_dock()
 
     def _on_adjust_intensity_button_clicked(self):
         if self.image_mosaic.intensity_adjusted[self.resolution_to_display]:
@@ -615,15 +643,23 @@ class StitchingWidget(QWidget):
                 )
                 return
 
-        self.image_mosaic.fuse(
+        worker = fuse_worker(
+            self.image_mosaic,
             output_path,
             normalise_intensity=self.normalise_intensity_toggle.isChecked(),
-            normalise_intensity_percentile=self.percentile_field.value(),
+            percentile=self.percentile_field.value(),
             interpolate=self.interpolate_overlaps_toggle.isChecked(),
         )
+        self._current_output_path = output_path
+        self._activate_activity_dock()
+        worker.finished.connect(self._on_fuse_finished)
+        worker.start()
 
+    def _on_fuse_finished(self):
+        output_path = self._current_output_path
         show_info("Fusing complete")
         display_info(self, "Info", f"Fused image saved to {output_path}")
+        self._deactivate_activity_dock()
 
     def check_imagej_path(self) -> None:
         """

--- a/brainglobe_stitch/stitching_widget.py
+++ b/brainglobe_stitch/stitching_widget.py
@@ -1,8 +1,8 @@
 import shutil
+import warnings
 from collections.abc import Generator
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple
-import warnings
 
 import dask.array as da
 import h5py

--- a/brainglobe_stitch/stitching_widget.py
+++ b/brainglobe_stitch/stitching_widget.py
@@ -71,12 +71,14 @@ def add_tiles_from_mosaic(
 def add_tiles_worker(napari_data, image_mosaic):
     yield from add_tiles_from_mosaic(napari_data, image_mosaic)
 
+
 @thread_worker(
     progress={"total": 100, "desc": "Creating resolution pyramid"},
 )
 def create_pyramid_worker(h5_path):
     for progress in create_pyramid_bdv_h5(h5_path):
         yield progress
+
 
 @thread_worker(
     progress={"total": 0, "desc": "Stitching tiles"},
@@ -88,6 +90,7 @@ def stitching_worker(image_mosaic, imagej_path, resolution_level, channel):
         selected_channel=channel,
     )
     return True
+
 
 class StitchingWidget(QWidget):
     """

--- a/brainglobe_stitch/stitching_widget.py
+++ b/brainglobe_stitch/stitching_widget.py
@@ -10,7 +10,7 @@ import numpy as np
 import numpy.typing as npt
 from brainglobe_utils.qtpy.logo import header_widget
 from napari import Viewer
-from napari.qt.threading import create_worker
+from napari.qt import thread_worker
 from napari.utils.notifications import show_info, show_warning
 from qt_niu.dialog import display_info, display_warning
 from qtpy.QtWidgets import (
@@ -66,6 +66,28 @@ def add_tiles_from_mosaic(
 
         yield tile_layer
 
+
+@thread_worker
+def add_tiles_worker(napari_data, image_mosaic):
+    yield from add_tiles_from_mosaic(napari_data, image_mosaic)
+
+@thread_worker(
+    progress={"total": 100, "desc": "Creating resolution pyramid"},
+)
+def create_pyramid_worker(h5_path):
+    for progress in create_pyramid_bdv_h5(h5_path):
+        yield progress
+
+@thread_worker(
+    progress={"total": 0, "desc": "Stitching tiles"},
+)
+def stitching_worker(image_mosaic, imagej_path, resolution_level, channel):
+    image_mosaic.stitch(
+        imagej_path,
+        resolution_level=resolution_level,
+        selected_channel=channel,
+    )
+    return True
 
 class StitchingWidget(QWidget):
     """
@@ -295,6 +317,7 @@ class StitchingWidget(QWidget):
 
         self.layout().addWidget(self.progress_bar)
         self.progress_bar.setVisible(False)
+        self._viewer.window._status_bar._toggle_activity_dock(True)
 
     def _on_open_file_dialog_clicked(self) -> None:
         """
@@ -329,11 +352,7 @@ class StitchingWidget(QWidget):
         self.progress_bar.setValue(0)
         self.progress_bar.setRange(0, 100)
 
-        worker = create_worker(
-            create_pyramid_bdv_h5,
-            self.h5_path,
-            yield_progress=True,
-        )
+        worker = create_pyramid_worker(self.h5_path)
         worker.yielded.connect(self.progress_bar.setValue)
         worker.finished.connect(self._create_pyramid_finished)
         worker.start()
@@ -369,9 +388,7 @@ class StitchingWidget(QWidget):
             self.resolution_to_display
         )
 
-        worker = create_worker(
-            add_tiles_from_mosaic, napari_data, self.image_mosaic
-        )
+        worker = add_tiles_worker(napari_data, self.image_mosaic)
         worker.yielded.connect(self._set_tile_layers)
         worker.start()
         self.adjust_intensity_button.setEnabled(True)
@@ -453,11 +470,11 @@ class StitchingWidget(QWidget):
             display_info(self, "Warning", error_message)
             return
 
-        worker = create_worker(
-            self.image_mosaic.stitch,
+        worker = stitching_worker(
+            self.image_mosaic,
             self.imagej_path,
             resolution_level=2,
-            selected_channel=self.fuse_channel_dropdown.currentText(),
+            channel=self.fuse_channel_dropdown.currentText(),
         )
 
         self.fuse_button.setEnabled(False)

--- a/brainglobe_stitch/stitching_widget.py
+++ b/brainglobe_stitch/stitching_widget.py
@@ -2,6 +2,7 @@ import shutil
 from collections.abc import Generator
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple
+import warnings
 
 import dask.array as da
 import h5py
@@ -339,10 +340,14 @@ class StitchingWidget(QWidget):
         self.progress_bar.setVisible(False)
     
     def _activate_activity_dock(self):
-        self._viewer.window._status_bar._toggle_activity_dock(True)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", FutureWarning)
+            self._viewer.window._status_bar._toggle_activity_dock(True)
 
     def _deactivate_activity_dock(self):
-        self._viewer.window._status_bar._toggle_activity_dock(False)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", FutureWarning)
+            self._viewer.window._status_bar._toggle_activity_dock(False)
 
     def _on_open_file_dialog_clicked(self) -> None:
         """

--- a/tests/test_unit/test_stitching_widget.py
+++ b/tests/test_unit/test_stitching_widget.py
@@ -376,7 +376,7 @@ def test_on_stitch_button_clicked(
     )
 
     mock_worker_instance.start.assert_called_once()
-        
+
 
 def test_on_stitch_button_clicked_no_image_mosaic(
     stitching_widget, test_constants, mocker

--- a/tests/test_unit/test_stitching_widget.py
+++ b/tests/test_unit/test_stitching_widget.py
@@ -365,19 +365,23 @@ def test_on_stitch_button_clicked(
     stitching_widget = stitching_widget_with_mosaic
     stitching_widget.imagej_path = test_constants["MOCK_IMAGEJ_EXEC_PATH"]
 
+    mock_worker_instance = mocker.Mock()
     mock_worker = mocker.patch(
         "brainglobe_stitch.stitching_widget.stitching_worker",
+        return_value=mock_worker_instance,
     )
 
     stitching_widget._on_stitch_button_clicked()
 
     mock_worker.assert_called_once_with(
-        stitching_widget_with_mosaic.image_mosaic,
+        stitching_widget.image_mosaic,
         stitching_widget.imagej_path,
         resolution_level=2,
         channel="",
     )
 
+    mock_worker_instance.start.assert_called_once()
+        
 
 def test_on_stitch_button_clicked_no_image_mosaic(
     stitching_widget, test_constants, mocker
@@ -640,15 +644,15 @@ def test_on_open_dialog_output_clicked_cancelled(stitching_widget, mocker):
 def test_on_fuse_button_clicked(
     stitching_widget_with_mosaic, mocker, file_name
 ):
-    mock_display_info = mocker.patch(
-        "brainglobe_stitch.stitching_widget.display_info",
-        autospec=True,
-    )
     stitching_widget = stitching_widget_with_mosaic
 
-    mock_fuse = mocker.patch(
-        "brainglobe_stitch.stitching_widget.ImageMosaic.fuse",
-        autospec=True,
+    mock_worker_instance = mocker.Mock()
+    mock_worker_instance.finished = mocker.Mock()
+    mock_worker_instance.start = mocker.Mock()
+
+    mock_fuse_worker = mocker.patch(
+        "brainglobe_stitch.stitching_widget.fuse_worker",
+        return_value=mock_worker_instance,
     )
 
     output_path = stitching_widget.working_directory / file_name
@@ -656,19 +660,34 @@ def test_on_fuse_button_clicked(
 
     stitching_widget._on_fuse_button_clicked()
 
-    mock_fuse.assert_called_once_with(
+    mock_fuse_worker.assert_called_once_with(
         stitching_widget.image_mosaic,
         output_path,
         normalise_intensity=False,
-        normalise_intensity_percentile=80,
+        percentile=80,
         interpolate=False,
     )
-    mock_display_info.assert_called_once_with(
-        stitching_widget,
-        "Info",
-        f"Fused image saved to "
-        f"{stitching_widget.working_directory / file_name}",
+
+    mock_worker_instance.start.assert_called_once()
+
+    assert stitching_widget._current_output_path == output_path
+
+
+def test_on_fuse_finished(stitching_widget_with_mosaic, mocker):
+    mock_show_info = mocker.patch(
+        "brainglobe_stitch.stitching_widget.show_info"
     )
+    mock_display_info = mocker.patch(
+        "brainglobe_stitch.stitching_widget.display_info",
+        autospec=True,
+    )
+
+    stitching_widget_with_mosaic._current_output_path = Path("test.h5")
+
+    stitching_widget_with_mosaic._on_fuse_finished()
+
+    mock_show_info.assert_called_once_with("Fusing complete")
+    mock_display_info.assert_called_once()
 
 
 def test_on_fuse_button_clicked_no_file_name(

--- a/tests/test_unit/test_stitching_widget.py
+++ b/tests/test_unit/test_stitching_widget.py
@@ -6,7 +6,6 @@ import napari.layers
 import numpy as np
 import pytest
 
-import brainglobe_stitch
 from brainglobe_stitch.image_mosaic import ImageMosaic
 from brainglobe_stitch.stitching_widget import (
     StitchingWidget,
@@ -144,9 +143,7 @@ def test_on_create_pyramid_button_clicked(stitching_widget, mocker):
     should be enabled.
     """
     stitching_widget.h5_path = Path.home() / "test_path"
-    mocker.patch(
-        "brainglobe_stitch.stitching_widget.create_pyramid_worker"
-    )
+    mocker.patch("brainglobe_stitch.stitching_widget.create_pyramid_worker")
 
     stitching_widget._on_create_pyramid_button_clicked()
 
@@ -165,9 +162,7 @@ def test_on_add_tiles_button_clicked(
     """
     stitching_widget.working_directory = naive_bdv_directory
 
-    mocker.patch(
-        "brainglobe_stitch.stitching_widget.add_tiles_worker"
-    )
+    mocker.patch("brainglobe_stitch.stitching_widget.add_tiles_worker")
 
     stitching_widget._on_add_tiles_button_clicked()
 

--- a/tests/test_unit/test_stitching_widget.py
+++ b/tests/test_unit/test_stitching_widget.py
@@ -10,6 +10,10 @@ from brainglobe_stitch.image_mosaic import ImageMosaic
 from brainglobe_stitch.stitching_widget import (
     StitchingWidget,
     add_tiles_from_mosaic,
+    add_tiles_worker,
+    create_pyramid_worker,
+    stitching_worker,
+    fuse_worker,
 )
 
 
@@ -32,6 +36,11 @@ def stitching_widget_with_mosaic(
     stitching_widget.image_mosaic.__del__()
 
 
+def test_activity_dock_methods(stitching_widget):
+    stitching_widget._activate_activity_dock()
+    stitching_widget._deactivate_activity_dock()
+
+
 def test_add_tiles_from_mosaic(
     naive_bdv_directory, stitching_widget_with_mosaic
 ):
@@ -51,6 +60,14 @@ def test_add_tiles_from_mosaic(
         assert (tile.translate == data[1]).all()
 
 
+def test_add_tiles_worker(stitching_widget_with_mosaic):
+    image_mosaic = stitching_widget_with_mosaic.image_mosaic
+    napari_data = image_mosaic.data_for_napari(0)
+
+    results = list(add_tiles_worker.__wrapped__(napari_data, image_mosaic))
+    assert len(results) == len(napari_data)
+
+
 def test_stitching_widget_init(make_napari_viewer_proxy):
     """
     Test that the StitchingWidget is correctly initialized with the viewer
@@ -65,6 +82,23 @@ def test_stitching_widget_init(make_napari_viewer_proxy):
     assert stitching_widget.image_mosaic is None
     assert len(stitching_widget.tile_layers) == 0
     assert stitching_widget.resolution_to_display == 3
+
+
+def test_stitching_worker(mocker):
+    mock_mosaic = mocker.Mock()
+
+    result = stitching_worker.__wrapped__(
+        mock_mosaic,
+        Path("imagej"),
+        resolution_level=2,
+        channel="",
+    )
+    mock_mosaic.stitch.assert_called_once_with(
+        Path("imagej"),
+        resolution_level=2,
+        selected_channel="",
+    )
+    assert result is True
 
 
 def test_on_open_file_dialog_clicked(stitching_widget, mocker):
@@ -149,6 +183,16 @@ def test_on_create_pyramid_button_clicked(stitching_widget, mocker):
 
     assert not stitching_widget.create_pyramid_button.isEnabled()
     assert stitching_widget.add_tiles_button.isEnabled()
+
+
+def test_create_pyramid_worker(mocker):
+    mocker.patch(
+        "brainglobe_stitch.stitching_widget.create_pyramid_bdv_h5",
+        return_value=[10, 50, 100],
+    )
+
+    result = list(create_pyramid_worker.__wrapped__(Path("dummy.h5")))
+    assert result == [10, 50, 100]
 
 
 def test_on_add_tiles_button_clicked(
@@ -733,6 +777,72 @@ def test_on_fuse_button_clicked_wrong_suffix(
     mock_display_info.assert_called_once_with(
         stitching_widget, "Warning", error_message
     )
+
+
+def test_fuse_worker(mocker):
+    mock_mosaic = mocker.Mock()
+
+    result = fuse_worker.__wrapped__(
+        mock_mosaic,
+        Path("output.h5"),
+        normalise_intensity=True,
+        percentile=90,
+        interpolate=True,
+    )
+    mock_mosaic.fuse.assert_called_once_with(
+        Path("output.h5"),
+        normalise_intensity=True,
+        normalise_intensity_percentile=90,
+        interpolate=True,
+    )
+    assert result is True
+
+
+def test_on_fuse_button_overwrite_confirm(
+    stitching_widget_with_mosaic, mocker, tmp_path
+):
+    stitching_widget = stitching_widget_with_mosaic
+
+    output_path = tmp_path / "existing.h5"
+    output_path.touch()
+    stitching_widget.select_output_path_text_field.setText(str(output_path))
+
+    mocker.patch(
+        "brainglobe_stitch.stitching_widget.display_warning",
+        return_value=True,
+    )
+    mock_worker_instance = mocker.Mock()
+    mock_worker_instance.finished = mocker.Mock()
+    mock_worker_instance.start = mocker.Mock()
+    mocker.patch(
+        "brainglobe_stitch.stitching_widget.fuse_worker",
+        return_value=mock_worker_instance,
+    )
+
+    stitching_widget._on_fuse_button_clicked()
+    assert not output_path.exists()
+
+
+def test_on_fuse_button_overwrite_cancel(
+    stitching_widget_with_mosaic, mocker, tmp_path
+):
+    stitching_widget = stitching_widget_with_mosaic
+
+    output_path = tmp_path / "existing.h5"
+    output_path.touch()
+    stitching_widget.select_output_path_text_field.setText(str(output_path))
+
+    mocker.patch(
+        "brainglobe_stitch.stitching_widget.display_warning",
+        return_value=False,
+    )
+    mock_show_warning = mocker.patch(
+        "brainglobe_stitch.stitching_widget.show_warning"
+    )
+
+    stitching_widget._on_fuse_button_clicked()
+    mock_show_warning.assert_called_once()
+    assert output_path.exists()
 
 
 def test_on_reset_preview_button_clicked_no_change(

--- a/tests/test_unit/test_stitching_widget.py
+++ b/tests/test_unit/test_stitching_widget.py
@@ -12,8 +12,8 @@ from brainglobe_stitch.stitching_widget import (
     add_tiles_from_mosaic,
     add_tiles_worker,
     create_pyramid_worker,
-    stitching_worker,
     fuse_worker,
+    stitching_worker,
 )
 
 

--- a/tests/test_unit/test_stitching_widget.py
+++ b/tests/test_unit/test_stitching_widget.py
@@ -138,25 +138,17 @@ def test_on_mesospim_directory_text_edited(stitching_widget, mocker):
 
 def test_on_create_pyramid_button_clicked(stitching_widget, mocker):
     """
-    Test that the on_create_pyramid_button_clicked method correctly calls
-    the create_worker function with the correct arguments. The create_worker
-    function is mocked to prevent actually creating the pyramid. The create
-    pyramid button is disabled should be disabled after the method is called
-    and the add_tiles_button should be enabled.
+    Test that clicking the create pyramid button starts the pyramid worker
+    and updates widget state correctly. After the method is called, the
+    create pyramid button should be disabled and the add_tiles_button
+    should be enabled.
     """
     stitching_widget.h5_path = Path.home() / "test_path"
-    mock_create_worker = mocker.patch(
-        "brainglobe_stitch.stitching_widget.create_worker",
-        autospec=True,
+    mocker.patch(
+        "brainglobe_stitch.stitching_widget.create_pyramid_worker"
     )
 
     stitching_widget._on_create_pyramid_button_clicked()
-
-    mock_create_worker.assert_called_once_with(
-        brainglobe_stitch.file_utils.create_pyramid_bdv_h5,
-        stitching_widget.h5_path,
-        yield_progress=True,
-    )
 
     assert not stitching_widget.create_pyramid_button.isEnabled()
     assert stitching_widget.add_tiles_button.isEnabled()
@@ -173,14 +165,11 @@ def test_on_add_tiles_button_clicked(
     """
     stitching_widget.working_directory = naive_bdv_directory
 
-    mock_create_worker = mocker.patch(
-        "brainglobe_stitch.stitching_widget.create_worker",
-        autospec=True,
+    mocker.patch(
+        "brainglobe_stitch.stitching_widget.add_tiles_worker"
     )
 
     stitching_widget._on_add_tiles_button_clicked()
-
-    mock_create_worker.assert_called_once()
 
     assert stitching_widget.image_mosaic is not None
 
@@ -376,18 +365,17 @@ def test_on_stitch_button_clicked(
     stitching_widget = stitching_widget_with_mosaic
     stitching_widget.imagej_path = test_constants["MOCK_IMAGEJ_EXEC_PATH"]
 
-    mock_create_worker = mocker.patch(
-        "brainglobe_stitch.stitching_widget.create_worker",
-        autospec=True,
+    mock_worker = mocker.patch(
+        "brainglobe_stitch.stitching_widget.stitching_worker",
     )
 
     stitching_widget._on_stitch_button_clicked()
 
-    mock_create_worker.assert_called_once_with(
-        stitching_widget_with_mosaic.image_mosaic.stitch,
+    mock_worker.assert_called_once_with(
+        stitching_widget_with_mosaic.image_mosaic,
         stitching_widget.imagej_path,
         resolution_level=2,
-        selected_channel="",
+        channel="",
     )
 
 
@@ -461,7 +449,7 @@ def test_on_stitch_finished(stitching_widget_with_mosaic, mocker):
     assert stitching_widget_with_mosaic.liner_interpolation_button.isEnabled()
 
 
-def tests_on_adjust_intensity_button_clicked(
+def test_on_adjust_intensity_button_clicked(
     stitching_widget_with_mosaic, mocker
 ):
     """


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [x] Addition of a new feature
- [ ] Other

**Why is this PR needed?**
- Long-running operations like ```resolution pyramid creation, stitching, and tile loading``` previously ran without clear progress feedback.

**What does this PR do?**
- Migrates stitching, pyramid creation, and tile loading to ```napari.qt.thread_worker```.
- Updates tests to reflect the new threading model.

## References
- Closes #39 

## How has this PR been tested?
- Verified Activity Dock behavior using a standalone ```@thread_worker(progress=…)``` example in napari.

## Is this a breaking change?
- No.

## Does this PR require an update to the documentation?
- No.

## Checklist:

- [x] The code has been tested locally
- [x] Tests have been added/updated to cover all new functionality (unit & integration)
- [ ] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
