### PR TITLE
Remove specific backend specification in dev optional dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ dev = [
   "pytest-cov",
   "pytest-mock",
   "pytest-qt",
-  "pyqt5",
+  "napari[all]",
   "coverage",
   "tox",
   "pooch",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ dev = [
   "pytest-cov",
   "pytest-mock",
   "pytest-qt",
-  "napari[all]",
+  "napari[all]>=0.6.1",
   "coverage",
   "tox",
   "pooch",


### PR DESCRIPTION
Removes `pyqt5` from the dev optional dependencies to instead rely on `napari[all]` to supply the default backend.